### PR TITLE
Better tactics

### DIFF
--- a/src/categoryTheory/thin.lean
+++ b/src/categoryTheory/thin.lean
@@ -11,24 +11,21 @@ class thin_cat (C : Type) extends category C :=
 
 namespace thin_cat
 
-def preorder_cat_full {C : Type} [C_struct : preorder C] {X Y : C} (F : X ⟶ Y)
-  : ∃ p : X ≤ Y, F = hom_of_le p :=
-  ⟨ le_of_hom F, by { symmetry, apply hom_of_le_le_of_hom}  ⟩ 
+  def preorder_cat_full {C : Type} [C_struct : preorder C] {X Y : C} (F : X ⟶ Y)
+    : ∃ p : X ≤ Y, F = hom_of_le p :=
+    ⟨ le_of_hom F, by { symmetry, apply hom_of_le_le_of_hom}  ⟩ 
 
-def from_preorder {P : Type} (P_struct : preorder P) : thin_cat P :=
-⟨ 
-  begin 
-    assume X Y F G,
-    cases (preorder_cat_full F) with p pF,
-    cases (preorder_cat_full G) with q qG,
-    rewrite pF, rewrite qG,
-  end 
-⟩ 
+  def from_preorder {P : Type} (P_struct : preorder P) : thin_cat P :=
+  ⟨ 
+    begin 
+      assume X Y F G,
+      cases (preorder_cat_full F) with p pF,
+      cases (preorder_cat_full G) with q qG,
+      rewrite pF, rewrite qG,
+    end 
+  ⟩ 
 
--- def preorder_cat_rw {C : Type} [C_struct : preorder C] {X Y : C} :
---   ((from_preorder C_struct).hom X Y) = (X ≤ Y) :=
-  
-
-
+  meta def by_thin : tactic unit :=
+  `[ repeat{assume _}, repeat{ repeat{ apply funext, assume _},apply thin_cat.K }]
 
 end thin_cat

--- a/src/generalTactics.lean
+++ b/src/generalTactics.lean
@@ -1,0 +1,78 @@
+import meta.expr
+
+open tactic
+open nat
+
+-- Tactic for print-debugging
+meta def trace_goal (iden : string) : tactic unit :=
+  do  
+    tactic.trace ("-- GOAL @ " ++ iden ++ " --"),
+    tactic.trace_state
+
+/- Takes a list of names, introduces new variables by those names,
+   and then returns a list of the names and corresponding expr's
+   paired together. 
+   REQUIRES: goal is a Pi type of at least n args, where n is
+    the length of the input list   
+-/
+meta def repeat_assume_pair : list name → tactic (list (name × expr))
+| [] := return []
+| (nm::nms) :=
+  (do
+    temp_nm ← mk_fresh_name,
+    e ← intro temp_nm,
+    rest ← repeat_assume_pair nms,
+    return $ (nm,e)::rest)
+  -- <|> (return [])
+
+/- Takes a list of names, introduces new variables by those names,
+   and then returns unit. 
+   REQUIRES: goal is a Pi type of at least n args, where n is
+    the length of the input list   
+-/
+meta def repeat_assume : list name → tactic unit :=
+  list.foldr (λ nm rest, intro nm >> rest) skip 
+
+/- Takes a list N=[nm_0,nm_1,...,nm_{|N|-1}] of names, and
+   1. does |N| introductions to get e_0,e_1,...,e_{|N|-1},
+   2. does tactic T
+   3. does `induction e_i with nm_i` for each i,
+   4. returns unit.
+
+   REQUIRES: goal is a Pi type of at least |N| args, each of which can
+   have induction applied. Also T must work after the introductions
+   Will only attach nm_i to the first induction arg of e_i.
+
+   EXAMPLE: If goal is of the form
+      ⊢ ∀ (x_0,...,x_n : X) (y : Y), Q
+   then doing 
+      repeat_assume_then_induct `[ assume y ] [`φ0,...,`φn]
+    will have the same effect as
+      assume x0 ... xn,
+      assume y,
+      induction x0 with φ0,
+      ...
+      induction xn with φn,
+    So the assumption of y is outside the induction. If it's not
+    important to assume y before inducting, then the repeat_assume_induct
+    tactic can be used, followed by assume y.
+-/
+meta def repeat_assume_then_induct (T : tactic unit) (N : list name) : tactic unit :=
+  do
+    assumptionList ← repeat_assume_pair N,
+    T,
+    let cmb := λ nm e (res : tactic unit), (induction e [nm]) >> res,
+    list.foldr (function.uncurry cmb) skip assumptionList
+
+meta def repeat_assume_induct : list name →  tactic unit :=
+  repeat_assume_then_induct skip
+
+/-
+  gen_nameList takes a "base name" nm and will generate n
+  unique names: nm0, nm1, ...
+  More user-readable way of generating fresh names
+-/
+def varFormat (baseName : name) (i : nat) : name :=
+  name.append_suffix baseName (nat.has_repr.repr i)
+def gen_nameList (baseName : name) (n : nat) : list name := 
+  list.map (varFormat baseName) (list.range n)

--- a/src/semantics/PPC_syntacticCat.lean
+++ b/src/semantics/PPC_syntacticCat.lean
@@ -5,11 +5,6 @@ open PPC_defn
 open PPC_defn.PPC_derives
 open PPC_synPoset
 open synCat
-
-meta def trace_goal (iden : string) : tactic unit :=
-  synPoset_tactics.trace_goal iden
-
-
 open specialCats
 
 instance ℂ_PPC : thin_cat PPC_eq := syn_cat

--- a/src/semantics/PPC_syntacticCat.lean
+++ b/src/semantics/PPC_syntacticCat.lean
@@ -6,6 +6,9 @@ open PPC_defn.PPC_derives
 open PPC_synPoset
 open synCat
 
+meta def trace_goal (iden : string) : tactic unit :=
+  synPoset_tactics.trace_goal iden
+
 
 open specialCats
 
@@ -13,17 +16,20 @@ instance ℂ_PPC : thin_cat PPC_eq := syn_cat
 
 namespace ℂ_PPC_tactics
 
-def Form : Type := PPC_Form
-def Der : has_derives Form := PPC_Der
-/-
-Tactic for doing constructions in ℂ_PPC which are actually just
-the derivation rules of the natural deduction calculus lifted onto
-equivalence classes
-Input should be of the form `[ apply XXX ]
-where XXX is a rule of PPC_Der
--/
-meta def lift_derive_ℂ_PPC (numobjs nummorphs : nat) : tactic unit → tactic unit :=
-  @synCat_tactics.lift_derive_syn_cat' Form Der numobjs nummorphs
+  def Form : Type := PPC_Form
+  def Der : has_derives Form := PPC_Der
+  /-
+  Tactic for doing constructions in ℂ_PPC which are actually just
+  the derivation rules of the natural deduction calculus lifted onto
+  equivalence classes
+  First two arguments are the number of objects and morphisms to assume
+  Tactic input should usually be of the form `[ apply XXX ]
+  where XXX is a rule of PPC_Der
+  -/
+  #check synCat_tactics.lift_derive_syn_cat
+  
+  meta def lift_derive_ℂ_PPC  : nat → nat → tactic unit →  tactic unit :=
+    @synCat_tactics.lift_derive_syn_cat Form Der
 
 
 
@@ -53,12 +59,19 @@ instance : CC_cat PPC_eq :=
   exp := (⊃⁼),
   eval := by lift_derive_ℂ_PPC 2 0 `[ 
                 -- φ⊃ψ & φ ⊢ ψ
-                apply PPC_derives_x.union_Hyp_and,
-                apply PPC_derives_x.modus_ponens ],
+                trace_goal "eval0",
+                apply PPC_derives_x.union_Hyp_and, 
+                trace_goal "eval1",
+                apply PPC_derives_x.modus_ponens,
+                trace_goal "eval2"
+              ],
   curry := by lift_derive_ℂ_PPC 3 1 `[ 
-                -- If φ & ψ ⊢ θ, then φ ⊢ ψ ⊃ θ
+                -- If φ_0 & φ_1 ⊢ φ_2, then φ_0 ⊢ φ_1 ⊃ φ_2
+                trace_goal "curry0",
                 apply impl_intro,
-                apply PPC_derives_x.and_Hyp_union ],
+                trace_goal "curry1",
+                apply PPC_derives_x.and_Hyp_union,
+                trace_goal "curry2" ],
   curry_β := λ {X Y Z} u, by apply thin_cat.K,
   curry_η := λ {X Y Z} v, by apply thin_cat.K,
 }

--- a/src/semantics/PPC_syntacticCat.lean
+++ b/src/semantics/PPC_syntacticCat.lean
@@ -22,8 +22,10 @@ equivalence classes
 Input should be of the form `[ apply XXX ]
 where XXX is a rule of PPC_Der
 -/
-meta def lift_derive_ℂ_PPC : tactic unit → tactic unit :=
-  @synCat_tactics.lift_derive_syn_cat Form Der
+meta def lift_derive_ℂ_PPC (numobjs nummorphs : nat) : tactic unit → tactic unit :=
+  @synCat_tactics.lift_derive_syn_cat' Form Der numobjs nummorphs
+
+
 
 end ℂ_PPC_tactics
 
@@ -33,13 +35,13 @@ open ℂ_PPC_tactics
 instance : FP_cat PPC_eq :=
 {
   unit := syn_obj PPC_Form.top,
-  term := by lift_derive_ℂ_PPC `[ apply truth ], -- φ ⊢ ⊤
+  term := by lift_derive_ℂ_PPC 1 0 `[ apply truth ], -- φ ⊢ ⊤
   unit_η := λ X f, by apply thin_cat.K,
   prod := (&⁼),
-  pr1 := by lift_derive_ℂ_PPC `[ apply and_eliml ], -- φ & ψ ⊢ φ
-  pr2 := by lift_derive_ℂ_PPC `[ apply and_elimr ], -- φ & ψ ⊢ ψ
+  pr1 := by lift_derive_ℂ_PPC 2 0 `[ apply and_eliml ], -- φ & ψ ⊢ φ
+  pr2 := by lift_derive_ℂ_PPC 2 0 `[ apply and_elimr ], -- φ & ψ ⊢ ψ
                 -- If θ ⊢ φ and θ ⊢ ψ, then θ ⊢ φ & ψ
-  pair := by lift_derive_ℂ_PPC `[ apply and_intro ],
+  pair := by lift_derive_ℂ_PPC 3 2 `[ apply and_intro ],
   prod_β1 := λ X Y Z f g, by apply thin_cat.K,
   prod_β2 := λ X Y Z f g, by apply thin_cat.K,
   prod_η :=  λ X Y, by apply thin_cat.K,
@@ -49,11 +51,11 @@ instance : FP_cat PPC_eq :=
 instance : CC_cat PPC_eq := 
 {
   exp := (⊃⁼),
-  eval := by lift_derive_ℂ_PPC `[ 
+  eval := by lift_derive_ℂ_PPC 2 0 `[ 
                 -- φ⊃ψ & φ ⊢ ψ
                 apply PPC_derives_x.union_Hyp_and,
                 apply PPC_derives_x.modus_ponens ],
-  curry := by lift_derive_ℂ_PPC `[ 
+  curry := by lift_derive_ℂ_PPC 3 1 `[ 
                 -- If φ & ψ ⊢ θ, then φ ⊢ ψ ⊃ θ
                 apply impl_intro,
                 apply PPC_derives_x.and_Hyp_union ],

--- a/src/semantics/syntacticCat.lean
+++ b/src/semantics/syntacticCat.lean
@@ -22,7 +22,7 @@ namespace synCat
 
   def derives_of_hom [Der : has_derives Form] {φ ψ : Form} (f : syn_obj φ ⟶ syn_obj ψ): 
     Der.derives (Der.singleHyp.singleton φ) ψ :=
-    Exists.fst(thin_cat.preorder_cat_full f)
+    le_of_hom f
 
 end synCat
 
@@ -63,7 +63,7 @@ namespace synCat_tactics
     <|> (return [])
 
   meta def induct_all : list expr → tactic unit :=
-    list.foldr (λ e rest, do h ← induction e, rest) skip
+    list.foldr (λ e rest, induction e >> rest) skip
 
   meta def cleanup : tactic unit :=
     `[ 
@@ -81,7 +81,7 @@ namespace synCat_tactics
   Tactic input should be of the form `[ apply XXX ]
   where XXX is a derivation rule of Der
   -/
-  meta def lift_derive_syn_cat' (numobjs : nat) (nummor : nat) (T : tactic unit) : tactic unit :=
+  meta def lift_derive_syn_cat (numobjs : nat) (nummor : nat) (T : tactic unit) : tactic unit :=
   do
     objs ← repeat_assume numobjs,
     -- trace (list.length objs),

--- a/src/semantics/syntacticCat.lean
+++ b/src/semantics/syntacticCat.lean
@@ -32,17 +32,15 @@ namespace synCat_tactics
 
   open tactic
   open nat
+
   /-
-    To instantiate these tactics for a specific deductive calculus,
-    create a namespace with Form and Der specifically def'd (with
-    those exact variable names), and then
-
-    meta def lift_derive_XXX : tactic unit → tactic unit :=
-    @synCat_tactics.lift_derive_syn_cat Form Der
+  Helper tactic for lift_derive_syn_cat. After the tactic argument to 
+  lift_derive_syn_cat has broken the derivation goal down, cleanup goes
+  through and applies derive_refl and/or {derives_of_hom; assumption} to
+  finish off the main goal. It then uses the thinness of the syntactic
+  category to prove that this construction must respect the ⊣⊢ equiv
+  relation. This should conclude the lifting proof.
   -/
-  variable {Form : Type}
-  variable [Der : has_derives Form]
-
   meta def cleanup {Form : Type} [Der : has_derives Form] : tactic unit :=
     `[ 
       repeat {
@@ -52,29 +50,30 @@ namespace synCat_tactics
       }, 
       thin_cat.by_thin ]
 
-  def varFormat (baseName : name) (i : nat) : name :=
-    name.append_suffix baseName (nat.has_repr.repr i)
-
-  def gen_nameList (baseName : name) (n : nat) : list name := 
-    list.map (varFormat baseName) (list.range n)
-
   /-
   Tactic for doing constructions in syn_cat which are actually just
   the derivation rules lifted onto equivalence classes
   First two arguments are the number of objects and morphisms to assume
   Tactic input should be of the form `[ apply XXX ]
   where XXX is a derivation rule of Der
+
+  To instantiate these tactics for a specific deductive calculus,
+  create a namespace with Form and Der specifically def'd (with
+  those exact variable names), and then
+
+  meta def lift_derive_XXX : tactic unit → tactic unit :=
+  @synCat_tactics.lift_derive_syn_cat Form Der
   -/
-  meta def lift_derive_syn_cat (numobjs : nat) (nummor : nat) (T : tactic unit) : tactic unit :=
+  meta def lift_derive_syn_cat {Form : Type} [Der : has_derives Form] (numobjs : nat) (nummor : nat) (T : tactic unit) : tactic unit :=
   do
-    synPoset_tactics.repeat_assume_induct (gen_nameList `φ_ numobjs),
-    synPoset_tactics.repeat_assume (gen_nameList `f_ nummor),
+    repeat_assume_induct (gen_nameList `φ_ numobjs),
+    repeat_assume (gen_nameList `f_ nummor),
     applyc `synCat.syn_hom,
-    synPoset_tactics.trace_goal "BEGIN",
+    trace_goal "BEGIN",
     trace "-- BEGIN USE TACTIC --",
     T,
     trace "-- END USE TACTIC --",
-    synPoset_tactics.trace_goal "END",
+    trace_goal "END",
     @cleanup Form Der 
 
 end synCat_tactics

--- a/src/semantics/syntacticPoset.lean
+++ b/src/semantics/syntacticPoset.lean
@@ -1,39 +1,4 @@
-import deduction.deduction category_theory.category.preorder
-
-namespace synPoset_tactics
-
-  open tactic
-  open nat
-
-  meta def trace_goal (iden : string) : tactic unit :=
-    do  
-      tactic.trace ("-- GOAL @ " ++ iden ++ " --"),
-      tactic.trace_state
-      
-  meta def repeat_assume_pair : list name → tactic (list (name × expr))
-  | [] := return []
-  | (nm::nms) :=
-    (do
-      temp_nm ← mk_fresh_name,
-      e ← intro temp_nm,
-      rest ← repeat_assume_pair nms,
-      return $ (nm,e)::rest)
-    -- <|> (return [])
-
-  meta def repeat_assume : list name → tactic unit :=
-    list.foldr (λ nm rest, intro nm >> rest) skip 
-
-  meta def repeat_assume_then_induct (T : tactic unit) (N : list name) : tactic unit :=
-    do
-      assumptionList ← repeat_assume_pair N,
-      T,
-      let cmb := λ nm e (res : tactic unit), (induction e [nm]) >> res,
-      list.foldr (function.uncurry cmb) skip assumptionList
-
-  meta def repeat_assume_induct : list name →  tactic unit :=
-    repeat_assume_then_induct skip
-
-end synPoset_tactics
+import generalTactics deduction.deduction category_theory.category.preorder
 
 namespace synPoset
 
@@ -104,8 +69,6 @@ namespace synPoset
 
   def Form_eq_order [Der : has_derives Form] : @Form_eq Form Der → @Form_eq Form Der → Prop 
     := quot.lift₂ synPoset.syn_preorder.le syn_preorder_liftable1 syn_preorder_liftable2
-
-  open synPoset_tactics
 
   instance syn_poset [Der : has_derives Form] : partial_order Form_eq :=
   { le := @Form_eq_order Form Der,

--- a/src/semantics/syntacticPoset.lean
+++ b/src/semantics/syntacticPoset.lean
@@ -41,7 +41,7 @@ namespace synPoset
 
   notation (name:=Form_eq_explicit) F ` _eq`:max := Form_eq_x F
 
-  def Form_eq_in [Der : has_derives Form] : Form → @Form_eq Form Der := quot.mk (⊣⊢) 
+  def Form_eq_in [Der : has_derives Form] : Form → Form _eq := quot.mk (⊣⊢) 
 
   notation (name:=PPC_eq_in) ⦃φ⦄ := Form_eq_in φ
 
@@ -101,8 +101,8 @@ namespace synPoset
       end
   }
 
-  instance syn_eq_pre {Form : Type} [Der : has_derives Form] : preorder (Form_eq_x Form) :=
-    @partial_order.to_preorder (Form_eq_x Form) synPoset.syn_poset
+  instance syn_eq_pre {Form : Type} [Der : has_derives Form] : preorder (Form _eq) :=
+    @partial_order.to_preorder (Form _eq) synPoset.syn_poset
 
 end synPoset
 


### PR DESCRIPTION
The lifting derivation tactics (as originally written) were a bit blunt, e.g. using a ton of `repeat`s. The goal with this PR is to improve them by writing them in a more principled monadic style.