### PR TITLE
Abstracted object & morphism counting tactic, made available interactively

### DIFF
--- a/src/generalTactics.lean
+++ b/src/generalTactics.lean
@@ -7,11 +7,19 @@ open nat
   open lean.parser (tk)
   open tactic.interactive («have»)
 
+def NEWLINE : char := char.of_nat 10
+def untilFirstEmptyLine (s : string) : string :=
+   string.intercalate "\n" $
+   list.take_while (λ k, k ≠ "") $ 
+   s.split_on NEWLINE
+
 -- Tactic for print-debugging
 meta def trace_goal (iden : string) : tactic unit :=
-  do  
-    tactic.trace ("-- GOAL @ " ++ iden ++ " --"),
-    tactic.trace_state
+  do 
+    trace ("\n-- GOAL @ " ++ iden ++ " --"),
+    st ← tactic.read,
+    let s := format.to_string (to_fmt st),
+    trace $ (untilFirstEmptyLine s) ++ "\n"
 
 /- Takes a list of names, introduces new variables by those names,
    and then returns a list of the names and corresponding expr's

--- a/src/semantics/syntacticCat.lean
+++ b/src/semantics/syntacticCat.lean
@@ -104,10 +104,10 @@ namespace synCat_tactics
       | _ := 3          -- LiftT?!! invoked: also do the first stage of cleanup
       end,
     -- Count & print how many objects and morphisms to assume
+    (numobjs,nummor) ← doCount,
     /- Assume objects and morphisms, 
       - use induction to get that every object is of the form ⦃φ⦄ for some φ:Form 
       - use syn_hom_inv to turn every assumed morphism into a derivation -/
-    (numobjs,nummor) ← doCount,
     repeat_assume_induct (gen_nameList `φ_ numobjs),
     repeat_assume_replace `synCat.syn_hom_inv (gen_nameList `f_ nummor),
     -- Turn the synCat hom goal to a derivation goal

--- a/src/semantics/syntacticCat.lean
+++ b/src/semantics/syntacticCat.lean
@@ -111,17 +111,21 @@ namespace synCat_tactics
       - use syn_hom_inv to turn every assumed morphism into a derivation -/
     repeat_assume_induct (gen_nameList `φ_ numobjs),
     repeat_assume_replace `synCat.syn_hom_inv (gen_nameList `f_ nummor),
+    trace_goal "Checkpoint 0",
     -- Turn the synCat hom goal to a derivation goal
     applyc `synCat.syn_hom,
+    trace_goal "Checkpoint 1",
   when (proceedLevel > 1) $ do
     -- Apply the input tactic
     T,
+    trace_goal "Checkpoint 2",
   when (proceedLevel > 2) $ do
     -- Eliminate other goals (first stage of cleanup)
     iterate (
       (applyc `deduction_basic.derive_refl)
       <|> assumption
     ),
+    trace_goal "Checkpoint 3",
   when (proceedLevel > 3) $ do
     -- Prove the coherences
     thin_cat.by_thin

--- a/src/semantics/syntacticCat.lean
+++ b/src/semantics/syntacticCat.lean
@@ -75,6 +75,12 @@ namespace synCat_tactics
   | `( Π _, %%newGoal) := sloppyMkCount newGoal >>= incrLeft
   | _ := return (0,0)
 
+  meta def doCount : tactic (nat × nat) :=
+    do
+    (numobjs,nummor) ← target >>= mkCount,
+    trace $ "Objs: " ++ (repr numobjs) ++ ", Morphs: " ++ (repr nummor),
+    return (numobjs,nummor)
+
   /-
   Tactic for doing constructions in syn_cat which are actually just
   the derivation rules lifted onto equivalence classes
@@ -98,11 +104,10 @@ namespace synCat_tactics
       | _ := 3          -- LiftT?!! invoked: also do the first stage of cleanup
       end,
     -- Count & print how many objects and morphisms to assume
-    (numobjs,nummor) ← target >>= mkCount,
-    trace $ "Objs: " ++ (repr numobjs) ++ ", Morphs: " ++ (repr nummor),
     /- Assume objects and morphisms, 
       - use induction to get that every object is of the form ⦃φ⦄ for some φ:Form 
       - use syn_hom_inv to turn every assumed morphism into a derivation -/
+    (numobjs,nummor) ← doCount,
     repeat_assume_induct (gen_nameList `φ_ numobjs),
     repeat_assume_replace `synCat.syn_hom_inv (gen_nameList `f_ nummor),
     -- Turn the synCat hom goal to a derivation goal
@@ -166,5 +171,5 @@ namespace synCat_tactics
 
 end synCat_tactics
 
-run_cmd add_interactive [`synCat_tactics.LiftT,`synCat_tactics.HeavyLiftT,`synCat_tactics.Lower]
+run_cmd add_interactive [`synCat_tactics.LiftT,`synCat_tactics.HeavyLiftT,`synCat_tactics.Lower,`synCat_tactics.doCount]
 

--- a/src/semantics/syntacticCat.lean
+++ b/src/semantics/syntacticCat.lean
@@ -75,9 +75,10 @@ namespace synCat_tactics
   | `( Π _, %%newGoal) := sloppyMkCount newGoal >>= incrLeft
   | _ := return (0,0)
 
-  meta def doCount : tactic (nat × nat) :=
+  meta def doCount (sloppy : parse (optional $ tk "?")) : tactic (nat × nat) :=
     do
-    (numobjs,nummor) ← target >>= mkCount,
+    let counter := match sloppy with none := mkCount | _ := sloppyMkCount end,
+    (numobjs,nummor) ← target >>= counter,
     trace $ "Objs: " ++ (repr numobjs) ++ ", Morphs: " ++ (repr nummor),
     return (numobjs,nummor)
 
@@ -104,7 +105,7 @@ namespace synCat_tactics
       | _ := 3          -- LiftT?!! invoked: also do the first stage of cleanup
       end,
     -- Count & print how many objects and morphisms to assume
-    (numobjs,nummor) ← doCount,
+    (numobjs,nummor) ← doCount none,
     /- Assume objects and morphisms, 
       - use induction to get that every object is of the form ⦃φ⦄ for some φ:Form 
       - use syn_hom_inv to turn every assumed morphism into a derivation -/
@@ -147,8 +148,7 @@ namespace synCat_tactics
       | _ := 3          -- LiftT?!! invoked: also do the first stage of cleanup
       end,
     -- Count & print how many objects and morphisms to assume
-    (numobjs,nummor) ← target >>= sloppyMkCount,
-    trace $ "Objs: " ++ (repr numobjs) ++ ", Morphs: " ++ (repr nummor),
+    (numobjs,nummor) ← doCount (some()),
     /- Assume objects and morphisms, 
       - use induction to get that every object is of the form ⦃φ⦄ for some φ:Form 
       - use syn_hom_inv to turn every assumed morphism into a derivation -/


### PR DESCRIPTION
Moves the process of counting objects & morphisms in goal into its own tactic, `doCount`, which is now available to users interactively